### PR TITLE
add bsides pyongyang

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ List of cybersecurity conference CFP deadlines.
 | [BSides Cymru](https://www.bsides.cymru/) | September 12, 2025 | October 17, 2025 | Cardiff, Wales | [CFP Link](https://pretalx.com/bsides-cymru-2025/cfp) |
 | [DistrictCon](https://www.districtcon.org/) | September 28, 2025 | January 24-25, 2026 | Washington DC | [Sessionize](https://sessionize.com/districtcon) |
 | [RE//verse](https://re-verse.io/) | November 14, 2025 | Mar 5-7, 2026 | Orlando, FL | [Sessionize](https://sessionize.com/reverse-2026) |
+| [BSides Pyongyang](https://bsidespyongyang.com/) | September 22, 2025 | November 18, 2025 | [CFP](https://docs.google.com/forms/d/e/1FAIpQLScz9MfOjoQcU432QyYM5z20G5Y8KiWJCfjnIWuCDcu5V778xw/viewform) |
 
 
 ## How to add a conference

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ List of cybersecurity conference CFP deadlines.
 | [BSides Cymru](https://www.bsides.cymru/) | September 12, 2025 | October 17, 2025 | Cardiff, Wales | [CFP Link](https://pretalx.com/bsides-cymru-2025/cfp) |
 | [DistrictCon](https://www.districtcon.org/) | September 28, 2025 | January 24-25, 2026 | Washington DC | [Sessionize](https://sessionize.com/districtcon) |
 | [RE//verse](https://re-verse.io/) | November 14, 2025 | Mar 5-7, 2026 | Orlando, FL | [Sessionize](https://sessionize.com/reverse-2026) |
-| [BSides Pyongyang](https://bsidespyongyang.com/) | September 22, 2025 | November 18, 2025 | [CFP](https://docs.google.com/forms/d/e/1FAIpQLScz9MfOjoQcU432QyYM5z20G5Y8KiWJCfjnIWuCDcu5V778xw/viewform) |
+| [BSides Pyongyang](https://bsidespyongyang.com/) | September 22, 2025 | November 18, 2025 | Pyongyang, DPRK & Virtual | [CFP](https://docs.google.com/forms/d/e/1FAIpQLScz9MfOjoQcU432QyYM5z20G5Y8KiWJCfjnIWuCDcu5V778xw/viewform) |
 
 
 ## How to add a conference


### PR DESCRIPTION
On 18 November 2025, BSides Pyongyang will host its first virtual conference.  As the leading cybersecurity conference in Pyongyang and the world for 30 years, this year's expansion will demonstrate the might of our bandwidth and our bravery. We welcome those equipped with the Juche and Songun ideals to firmly rally behind our Party and present original research on the intersection between cybersecurity and the Democratic People’s Republic of Korea. 

https://bsidespyongyang.com/